### PR TITLE
Add types for named exports

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -29,3 +29,5 @@ declare const _default: {
 };
  
 export default _default;
+export const Raven: RavenStatic;
+export const version: string;


### PR DESCRIPTION
Typescript was giving me a `Module '".../node_modules/vue-raven/types/index"' has no exported member 'Raven'. [2305]` error.